### PR TITLE
Fix issue 其它地方的“多说”评论会出现在博客的下面 #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,25 @@ Modify <code>theme</code> setting in blog folder <code>_config.yml</code> to <co
 
 Modify settings in the file <code>_config.yml</code>
 
+####enable duoshuo
+
+add short name of duoshuo in `_config.yml`:
+
+```
+duoshuo: 
+  enable: true  ## duoshuo.com
+  short_name: <your short name>    ## duoshuo short name.
+```
+
+edit `comment.ejs` to put the same short name here:
+
+```js
+var duoshuoQuery = {short_name:"<your short name>"};
+...
+```
 
 
-2014/08/04
+2014/08/06
 
 
 

--- a/Tinny/_config.yml
+++ b/Tinny/_config.yml
@@ -10,7 +10,9 @@ menu:
 ## ---
 
 #### site-header profile link
-
+profile:
+  enable: true
+  href: http://zhanglun.github.io/
 
 
 #### Widgets

--- a/Tinny/layout/_partial/post/comment.ejs
+++ b/Tinny/layout/_partial/post/comment.ejs
@@ -5,7 +5,7 @@
 <!-- 多说评论框 end -->
 <!-- 多说公共JS代码 start (一个网页只需插入一次) -->
 <script type="text/javascript">
-var duoshuoQuery = {short_name:"crispelite"};
+var duoshuoQuery = {short_name:"<your short name>"};
 	(function() {
 		var ds = document.createElement('script');
 		ds.type = 'text/javascript';ds.async = true;


### PR DESCRIPTION
Fix https://github.com/zhanglun/hexo-theme/issues/3

将`_config.yml`和`comment.ejs`的多说的`short name`改成一致后，评论不在乱入乱出现。
